### PR TITLE
fix: compile errors update to latest development

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2150,7 +2150,7 @@ dependencies = [
 [[package]]
 name = "minotari_ledger_wallet_common"
 version = "5.2.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.0-pre.2#b6faab4c047b9a60ba5bbe64f1f8c160108df831"
+source = "git+https://github.com/tari-project/tari.git?branch=development#c3e70eb9a2c6e4fba96d1e60e52e018d5cc8f54e"
 dependencies = [
  "bs58 0.5.1",
 ]
@@ -3554,7 +3554,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "tari_bor"
 version = "0.11.1"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#9eb0695c9f29ae011c0046262c6aa6c7a324b440"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#5e1465705affb07025c99c99f6a8559b5441a993"
 dependencies = [
  "borsh",
  "ciborium",
@@ -3586,7 +3586,7 @@ dependencies = [
 [[package]]
 name = "tari_common"
 version = "5.2.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.0-pre.2#b6faab4c047b9a60ba5bbe64f1f8c160108df831"
+source = "git+https://github.com/tari-project/tari.git?branch=development#c3e70eb9a2c6e4fba96d1e60e52e018d5cc8f54e"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -3609,7 +3609,7 @@ dependencies = [
 [[package]]
 name = "tari_common_types"
 version = "5.2.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.0-pre.2#b6faab4c047b9a60ba5bbe64f1f8c160108df831"
+source = "git+https://github.com/tari-project/tari.git?branch=development#c3e70eb9a2c6e4fba96d1e60e52e018d5cc8f54e"
 dependencies = [
  "argon2 0.4.1",
  "base64 0.21.7",
@@ -3646,7 +3646,7 @@ dependencies = [
 [[package]]
 name = "tari_consensus_types"
 version = "0.16.0"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#9eb0695c9f29ae011c0046262c6aa6c7a324b440"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#5e1465705affb07025c99c99f6a8559b5441a993"
 dependencies = [
  "borsh",
  "serde",
@@ -3685,7 +3685,7 @@ dependencies = [
 [[package]]
 name = "tari_engine_types"
 version = "0.16.0"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#9eb0695c9f29ae011c0046262c6aa6c7a324b440"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#5e1465705affb07025c99c99f6a8559b5441a993"
 dependencies = [
  "base64 0.21.7",
  "blake2",
@@ -3711,12 +3711,12 @@ dependencies = [
 [[package]]
 name = "tari_features"
 version = "5.2.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.0-pre.2#b6faab4c047b9a60ba5bbe64f1f8c160108df831"
+source = "git+https://github.com/tari-project/tari.git?branch=development#c3e70eb9a2c6e4fba96d1e60e52e018d5cc8f54e"
 
 [[package]]
 name = "tari_hashing"
 version = "5.2.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.0-pre.2#b6faab4c047b9a60ba5bbe64f1f8c160108df831"
+source = "git+https://github.com/tari-project/tari.git?branch=development#c3e70eb9a2c6e4fba96d1e60e52e018d5cc8f54e"
 dependencies = [
  "blake2",
  "borsh",
@@ -3727,7 +3727,7 @@ dependencies = [
 [[package]]
 name = "tari_indexer_client"
 version = "0.16.0"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#9eb0695c9f29ae011c0046262c6aa6c7a324b440"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#5e1465705affb07025c99c99f6a8559b5441a993"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -3755,7 +3755,7 @@ dependencies = [
 [[package]]
 name = "tari_jellyfish"
 version = "5.2.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.0-pre.2#b6faab4c047b9a60ba5bbe64f1f8c160108df831"
+source = "git+https://github.com/tari-project/tari.git?branch=development#c3e70eb9a2c6e4fba96d1e60e52e018d5cc8f54e"
 dependencies = [
  "borsh",
  "digest",
@@ -3769,7 +3769,7 @@ dependencies = [
 [[package]]
 name = "tari_max_size"
 version = "5.2.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.0-pre.2#b6faab4c047b9a60ba5bbe64f1f8c160108df831"
+source = "git+https://github.com/tari-project/tari.git?branch=development#c3e70eb9a2c6e4fba96d1e60e52e018d5cc8f54e"
 dependencies = [
  "borsh",
  "serde",
@@ -3780,7 +3780,7 @@ dependencies = [
 [[package]]
 name = "tari_mmr"
 version = "5.2.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.0-pre.2#b6faab4c047b9a60ba5bbe64f1f8c160108df831"
+source = "git+https://github.com/tari-project/tari.git?branch=development#c3e70eb9a2c6e4fba96d1e60e52e018d5cc8f54e"
 dependencies = [
  "borsh",
  "digest",
@@ -3794,7 +3794,7 @@ dependencies = [
 [[package]]
 name = "tari_ootle_address"
 version = "0.16.0"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#9eb0695c9f29ae011c0046262c6aa6c7a324b440"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#5e1465705affb07025c99c99f6a8559b5441a993"
 dependencies = [
  "bech32",
  "serde",
@@ -3808,7 +3808,7 @@ dependencies = [
 [[package]]
 name = "tari_ootle_common_types"
 version = "0.16.0"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#9eb0695c9f29ae011c0046262c6aa6c7a324b440"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#5e1465705affb07025c99c99f6a8559b5441a993"
 dependencies = [
  "blake2",
  "borsh",
@@ -3835,7 +3835,7 @@ dependencies = [
 [[package]]
 name = "tari_ootle_storage"
 version = "0.16.0"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#9eb0695c9f29ae011c0046262c6aa6c7a324b440"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#5e1465705affb07025c99c99f6a8559b5441a993"
 dependencies = [
  "anyhow",
  "bitflags 2.9.4",
@@ -3860,7 +3860,7 @@ dependencies = [
 [[package]]
 name = "tari_ootle_wallet_crypto"
 version = "0.16.0"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#9eb0695c9f29ae011c0046262c6aa6c7a324b440"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#5e1465705affb07025c99c99f6a8559b5441a993"
 dependencies = [
  "argon2 0.5.3",
  "blake2",
@@ -3883,7 +3883,7 @@ dependencies = [
 [[package]]
 name = "tari_ootle_wallet_sdk"
 version = "0.16.0"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#9eb0695c9f29ae011c0046262c6aa6c7a324b440"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#5e1465705affb07025c99c99f6a8559b5441a993"
 dependencies = [
  "anyhow",
  "blake2",
@@ -3916,7 +3916,7 @@ dependencies = [
 [[package]]
 name = "tari_ootle_wallet_sdk_services"
 version = "0.16.0"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#9eb0695c9f29ae011c0046262c6aa6c7a324b440"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#5e1465705affb07025c99c99f6a8559b5441a993"
 dependencies = [
  "anyhow",
  "futures",
@@ -3942,7 +3942,7 @@ dependencies = [
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
 version = "0.16.0"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#9eb0695c9f29ae011c0046262c6aa6c7a324b440"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#5e1465705affb07025c99c99f6a8559b5441a993"
 dependencies = [
  "bigdecimal",
  "diesel",
@@ -3966,7 +3966,7 @@ dependencies = [
 [[package]]
 name = "tari_script"
 version = "5.2.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.0-pre.2#b6faab4c047b9a60ba5bbe64f1f8c160108df831"
+source = "git+https://github.com/tari-project/tari.git?branch=development#c3e70eb9a2c6e4fba96d1e60e52e018d5cc8f54e"
 dependencies = [
  "blake2",
  "borsh",
@@ -3984,7 +3984,7 @@ dependencies = [
 [[package]]
 name = "tari_service_framework"
 version = "5.2.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.0-pre.2#b6faab4c047b9a60ba5bbe64f1f8c160108df831"
+source = "git+https://github.com/tari-project/tari.git?branch=development#c3e70eb9a2c6e4fba96d1e60e52e018d5cc8f54e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3999,7 +3999,7 @@ dependencies = [
 [[package]]
 name = "tari_shutdown"
 version = "5.2.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.0-pre.2#b6faab4c047b9a60ba5bbe64f1f8c160108df831"
+source = "git+https://github.com/tari-project/tari.git?branch=development#c3e70eb9a2c6e4fba96d1e60e52e018d5cc8f54e"
 dependencies = [
  "futures",
 ]
@@ -4007,7 +4007,7 @@ dependencies = [
 [[package]]
 name = "tari_sidechain"
 version = "5.2.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.0-pre.2#b6faab4c047b9a60ba5bbe64f1f8c160108df831"
+source = "git+https://github.com/tari-project/tari.git?branch=development#c3e70eb9a2c6e4fba96d1e60e52e018d5cc8f54e"
 dependencies = [
  "borsh",
  "hex",
@@ -4024,7 +4024,7 @@ dependencies = [
 [[package]]
 name = "tari_state_tree"
 version = "0.16.0"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#9eb0695c9f29ae011c0046262c6aa6c7a324b440"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#5e1465705affb07025c99c99f6a8559b5441a993"
 dependencies = [
  "log",
  "serde",
@@ -4039,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "tari_template_abi"
 version = "0.14.0"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#9eb0695c9f29ae011c0046262c6aa6c7a324b440"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#5e1465705affb07025c99c99f6a8559b5441a993"
 dependencies = [
  "serde",
  "tari_bor",
@@ -4048,7 +4048,7 @@ dependencies = [
 [[package]]
 name = "tari_template_builtin"
 version = "0.16.0"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#9eb0695c9f29ae011c0046262c6aa6c7a324b440"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#5e1465705affb07025c99c99f6a8559b5441a993"
 dependencies = [
  "tari_template_lib",
 ]
@@ -4056,7 +4056,7 @@ dependencies = [
 [[package]]
 name = "tari_template_lib"
 version = "0.14.0"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#9eb0695c9f29ae011c0046262c6aa6c7a324b440"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#5e1465705affb07025c99c99f6a8559b5441a993"
 dependencies = [
  "borsh",
  "serde",
@@ -4069,7 +4069,7 @@ dependencies = [
 [[package]]
 name = "tari_template_lib_types"
 version = "0.14.0"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#9eb0695c9f29ae011c0046262c6aa6c7a324b440"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#5e1465705affb07025c99c99f6a8559b5441a993"
 dependencies = [
  "bnum",
  "borsh",
@@ -4082,7 +4082,7 @@ dependencies = [
 [[package]]
 name = "tari_template_macros"
 version = "0.14.0"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#9eb0695c9f29ae011c0046262c6aa6c7a324b440"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#5e1465705affb07025c99c99f6a8559b5441a993"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4094,7 +4094,7 @@ dependencies = [
 [[package]]
 name = "tari_transaction"
 version = "0.16.0"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#9eb0695c9f29ae011c0046262c6aa6c7a324b440"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#5e1465705affb07025c99c99f6a8559b5441a993"
 dependencies = [
  "borsh",
  "hex",
@@ -4114,7 +4114,7 @@ dependencies = [
 [[package]]
 name = "tari_transaction_components"
 version = "5.2.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.0-pre.2#b6faab4c047b9a60ba5bbe64f1f8c160108df831"
+source = "git+https://github.com/tari-project/tari.git?branch=development#c3e70eb9a2c6e4fba96d1e60e52e018d5cc8f54e"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,15 +17,13 @@ tari_ootle_common_types = { git = "https://github.com/tari-project/tari-ootle.gi
 tari_engine_types = { git = "https://github.com/tari-project/tari-ootle.git", branch = "development" }
 tari_transaction = { git = "https://github.com/tari-project/tari-ootle.git", branch = "development" }
 
-# tari_ootle_wallet_sdk = { path = "../tari-dan/crates/wallet/sdk" }
-# tari_ootle_wallet_sdk_services = { path = "../tari-dan/crates/wallet/sdk_services", features = [
-#     "indexer_client",
-# ] }
-# tari_ootle_wallet_storage_sqlite = { path = "../tari-dan/crates/wallet/storage_sqlite" }
-# tari_template_lib_types = { path = "../tari-dan/crates/template_lib_types" }
-# tari_ootle_common_types = { path = "../tari-dan/crates/common_types" }
-# tari_engine_types = { path = "../tari-dan/crates/engine_types" }
-# tari_transaction = { path = "../tari-dan/crates/transaction" }
+#tari_ootle_wallet_sdk = { path = "../dan/crates/wallet/sdk" }
+#tari_ootle_wallet_sdk_services = { path = "../dan/crates/wallet/sdk_services", features = ["indexer_client"] }
+#tari_ootle_wallet_storage_sqlite = { path = "../dan/crates/wallet/storage_sqlite" }
+#tari_template_lib_types = { path = "../dan/crates/template_lib_types" }
+#tari_ootle_common_types = { path = "../dan/crates/common_types" }
+#tari_engine_types = { path = "../dan/crates/engine_types" }
+#tari_transaction = { path = "../dan/crates/transaction" }
 
 tari_crypto = { version = "0.22.1", features = ["std"] }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ mod wallet;
 
 use crate::spinner::spinner;
 use crate::table::Table;
-use crate::transfer::{TransferCommand, handle_transfer_command};
+use crate::transfer::{handle_transfer_command, TransferCommand};
 use crate::wallet::{BalanceStuff, Sdk, Wallet};
 use anyhow::Context;
 use clap::{Parser, Subcommand};
@@ -19,13 +19,14 @@ use tari_crypto::ristretto::RistrettoSecretKey;
 use tari_crypto::tari_utilities::hex::from_hex;
 use tari_crypto::tari_utilities::{ByteArray, SafePassword};
 use tari_engine_types::template_lib_models::ResourceAddress;
-use tari_ootle_common_types::Network;
 use tari_ootle_common_types::displayable::Displayable;
+use tari_ootle_common_types::Network;
 use tari_ootle_wallet_sdk::constants::XTR;
 use tari_ootle_wallet_sdk::models::{AccountWithAddress, EpochBirthday};
 use tari_ootle_wallet_sdk_services::indexer_rest_api::IndexerRestApiNetworkInterface;
 use tari_ootle_wallet_storage_sqlite::SqliteWalletStore;
 use tari_template_lib_types::crypto::RistrettoPublicKeyBytes;
+use tari_template_lib_types::Amount;
 use termimad::crossterm::style::Color;
 use url::Url;
 use zeroize::Zeroizing;
@@ -371,7 +372,7 @@ async fn main() -> Result<(), anyhow::Error> {
                     let message = utxo.memo.as_ref().and_then(|m| m.as_memo_message());
                     table.add_row(table_row![
                         utxo.commitment,
-                        utxo.value.to_decimal_string(resource.divisibility() as u32),
+                        Amount::from(utxo.value).to_decimal_string(resource.divisibility() as u32),
                         message.display()
                     ]);
                 }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use crate::models::BalanceEntry;
-use anyhow::Context;
 use anyhow::anyhow;
+use anyhow::Context;
 use log::*;
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
@@ -12,9 +12,9 @@ use tari_engine_types::template_lib_models::{
     ComponentAddress, ResourceAddress, StealthTransferStatement, UtxoAddress,
 };
 use tari_engine_types::{FromByteType, ToByteType};
-use tari_ootle_common_types::Epoch;
 use tari_ootle_common_types::displayable::Displayable;
 use tari_ootle_common_types::optional::Optional;
+use tari_ootle_common_types::Epoch;
 use tari_ootle_common_types::{Network, SubstateRequirement};
 use tari_ootle_wallet_sdk::apis::confidential_transfer::UtxoInputSelection;
 use tari_ootle_wallet_sdk::apis::stealth_outputs::TransferStatementParams;
@@ -24,11 +24,11 @@ use tari_ootle_wallet_sdk::constants::{
     XTR, XTR_FAUCET_COMPONENT_ADDRESS, XTR_FAUCET_VAULT_ADDRESS,
 };
 use tari_ootle_wallet_sdk::crypto::memo::Memo;
-use tari_ootle_wallet_sdk::models::WalletEvent;
 use tari_ootle_wallet_sdk::models::{
-    AccountWithAddress, KeyBranch, KeyId, KeyType, NewAccountData, StealthOutputModel,
-    TransactionStatus, WalletLockId, WalletTransaction,
+    AccountWithAddress, KeyBranch, KeyId, KeyType, NewAccountData, TransactionStatus, WalletLockId,
+    WalletTransaction,
 };
+use tari_ootle_wallet_sdk::models::{StealthOutputInfo, WalletEvent};
 use tari_ootle_wallet_sdk::network::WalletNetworkInterface;
 use tari_ootle_wallet_sdk::{OotleAddress, RistrettoOotleAddress, SeedWords, WalletSdk};
 use tari_ootle_wallet_sdk_services::account_monitor::AccountScanner;
@@ -38,7 +38,7 @@ use tari_ootle_wallet_sdk_services::utxo_scanner::{UtxoRecovery, UtxoScanner};
 use tari_ootle_wallet_storage_sqlite::SqliteWalletStore;
 use tari_template_lib_types::crypto::RistrettoPublicKeyBytes;
 use tari_template_lib_types::{Amount, ResourceType};
-use tari_transaction::{Transaction, TransactionId, UnsignedTransaction, args};
+use tari_transaction::{args, Transaction, TransactionId, UnsignedTransaction};
 use tokio::sync::broadcast;
 
 pub type Sdk = WalletSdk<SqliteWalletStore, IndexerRestApiNetworkInterface>;
@@ -120,12 +120,11 @@ impl Wallet {
             let (utxo_count, confidential_balance) = if vault.resource_type.is_stealth() {
                 let (utxo_count, stealth_balance) = stealth_outputs
                     .iter()
-                    .filter(|o| {
-                        o.owner_account == *account_address
-                            && o.resource_address == vault.resource_address
-                    })
+                    .filter(|o| o.resource_address == vault.resource_address)
                     .map(|o| o.value)
-                    .fold((0usize, Amount::zero()), |(cnt, acc), o| (cnt + 1, acc + o));
+                    .fold((0usize, Amount::zero()), |(cnt, acc), o| {
+                        (cnt + 1, acc + Amount::from(o))
+                    });
 
                 if stealth_balance.is_positive() {
                     // If the vault exists, we add the confidential balance to this entry and, we don't want to add it again to the balances list for stealth utxos below.
@@ -156,9 +155,9 @@ impl Wallet {
                 acc.entry(o.resource_address)
                     .and_modify(|(cnt, v)| {
                         *cnt += 1;
-                        *v += o.value
+                        *v += Amount::from(o.value)
                     })
-                    .or_insert((1, o.value));
+                    .or_insert((1, Amount::from(o.value)));
                 acc
             });
 
@@ -435,14 +434,18 @@ impl Wallet {
         let spends_revealed_funds = inputs_to_spend.revealed.is_positive();
 
         let ch_memo = Memo::new_message("Change").unwrap();
+        let output_amount =
+            inputs_to_spend.total_amount() - Amount::from(amount) - Amount::from(fee_amount);
+        let output_amount = output_amount.to_u64_checked().ok_or_else(|| {
+            // Techincally, you could split this into multiple outputs, but this is very unlikely to ever be needed in practice
+            anyhow::anyhow!("Calculated change amount exceeds u64::MAX: {output_amount}")
+        })?;
         let change_output = Some(StealthOutputToCreate {
             owner_address: src_address,
-            amount: inputs_to_spend.total_amount()
-                - Amount::from(amount)
-                - Amount::from(fee_amount),
+            amount: output_amount,
             memo: Some(&ch_memo),
         })
-        .filter(|o| o.amount.is_positive());
+        .filter(|o| o.amount > 0);
 
         let memos = outputs
             .iter()
@@ -663,5 +666,5 @@ pub struct TransferOutput {
 
 pub struct BalanceStuff {
     pub balances: Vec<BalanceEntry>,
-    pub utxos: Vec<StealthOutputModel>,
+    pub utxos: Vec<StealthOutputInfo>,
 }


### PR DESCRIPTION
This pull request updates the codebase to improve type consistency and correctness in handling amounts and stealth outputs, as well as updates dependency paths to reflect a new directory structure. The main changes focus on using the `Amount` type more consistently, refining filtering logic, and updating dependency references.

**Dependency Path Updates**
* Updated commented-out local dependency paths in `Cargo.toml` to reflect a move from `../tari-dan/crates/...` to `../dan/crates/...`, ensuring future local development uses the correct directory structure.

**Type Consistency and Amount Handling**
* Replaced direct usage of numeric values with the `Amount` type in multiple locations, including UTXO display logic and balance calculations, to ensure type safety and prevent potential overflow issues. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL374-R375) [[2]](diffhunk://#diff-4db9c4cca2ff80c2ad80cbf7111959e148b31ee24cb354f8620c417047fe7b46L123-R127) [[3]](diffhunk://#diff-4db9c4cca2ff80c2ad80cbf7111959e148b31ee24cb354f8620c417047fe7b46L159-R160) [[4]](diffhunk://#diff-4db9c4cca2ff80c2ad80cbf7111959e148b31ee24cb354f8620c417047fe7b46R437-R448)
* Added explicit conversion and overflow checking when calculating change amounts in stealth outputs, improving error handling and reliability.

**Stealth Output Model Updates**
* Changed the type of the `utxos` field in the `BalanceStuff` struct from `StealthOutputModel` to `StealthOutputInfo` for improved clarity and correctness.
* Refined filtering logic for stealth outputs to only match by `resource_address`, simplifying and correcting the balance calculation.

**General Code Quality**
* Reordered imports for clarity and consistency, and resolved minor import issues. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL13-R13) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL22-R29) [[3]](diffhunk://#diff-4db9c4cca2ff80c2ad80cbf7111959e148b31ee24cb354f8620c417047fe7b46L5-R6) [[4]](diffhunk://#diff-4db9c4cca2ff80c2ad80cbf7111959e148b31ee24cb354f8620c417047fe7b46L15-R17) [[5]](diffhunk://#diff-4db9c4cca2ff80c2ad80cbf7111959e148b31ee24cb354f8620c417047fe7b46L27-R31) [[6]](diffhunk://#diff-4db9c4cca2ff80c2ad80cbf7111959e148b31ee24cb354f8620c417047fe7b46L41-R41)