### PR TITLE
fix: update code to ootle v0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3333,6 +3333,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "tari_bor"
 version = "0.11.1"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#1a3737043ac28324838946c1b664a66f07421856"
 dependencies = [
  "borsh",
  "ciborium",
@@ -3363,8 +3364,8 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "5.2.0-pre.4"
-source = "git+https://github.com/tari-project/tari.git?branch=development#d1772745dec8d231b54c689fcaf7470ab5ed455c"
+version = "5.2.0-pre.5"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.0-pre.5#ee8e46d8694e4144ecce7e3cc3e3773bad680314"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -3386,8 +3387,8 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "5.2.0-pre.4"
-source = "git+https://github.com/tari-project/tari.git?branch=development#d1772745dec8d231b54c689fcaf7470ab5ed455c"
+version = "5.2.0-pre.5"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.0-pre.5#ee8e46d8694e4144ecce7e3cc3e3773bad680314"
 dependencies = [
  "argon2 0.4.1",
  "base64 0.21.7",
@@ -3423,6 +3424,7 @@ dependencies = [
 [[package]]
 name = "tari_consensus_types"
 version = "0.16.0"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#1a3737043ac28324838946c1b664a66f07421856"
 dependencies = [
  "borsh",
  "serde",
@@ -3461,6 +3463,7 @@ dependencies = [
 [[package]]
 name = "tari_engine_types"
 version = "0.16.0"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#1a3737043ac28324838946c1b664a66f07421856"
 dependencies = [
  "base64 0.21.7",
  "blake2",
@@ -3485,13 +3488,13 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "5.2.0-pre.4"
-source = "git+https://github.com/tari-project/tari.git?branch=development#d1772745dec8d231b54c689fcaf7470ab5ed455c"
+version = "5.2.0-pre.5"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.0-pre.5#ee8e46d8694e4144ecce7e3cc3e3773bad680314"
 
 [[package]]
 name = "tari_hashing"
-version = "5.2.0-pre.4"
-source = "git+https://github.com/tari-project/tari.git?branch=development#d1772745dec8d231b54c689fcaf7470ab5ed455c"
+version = "5.2.0-pre.5"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.0-pre.5#ee8e46d8694e4144ecce7e3cc3e3773bad680314"
 dependencies = [
  "blake2",
  "borsh",
@@ -3502,6 +3505,7 @@ dependencies = [
 [[package]]
 name = "tari_indexer_client"
 version = "0.16.0"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#1a3737043ac28324838946c1b664a66f07421856"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -3528,8 +3532,8 @@ dependencies = [
 
 [[package]]
 name = "tari_jellyfish"
-version = "5.2.0-pre.4"
-source = "git+https://github.com/tari-project/tari.git?branch=development#d1772745dec8d231b54c689fcaf7470ab5ed455c"
+version = "5.2.0-pre.5"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.0-pre.5#ee8e46d8694e4144ecce7e3cc3e3773bad680314"
 dependencies = [
  "borsh",
  "digest",
@@ -3542,8 +3546,8 @@ dependencies = [
 
 [[package]]
 name = "tari_max_size"
-version = "5.2.0-pre.4"
-source = "git+https://github.com/tari-project/tari.git?branch=development#d1772745dec8d231b54c689fcaf7470ab5ed455c"
+version = "5.2.0-pre.5"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.0-pre.5#ee8e46d8694e4144ecce7e3cc3e3773bad680314"
 dependencies = [
  "borsh",
  "serde",
@@ -3553,8 +3557,8 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "5.2.0-pre.4"
-source = "git+https://github.com/tari-project/tari.git?branch=development#d1772745dec8d231b54c689fcaf7470ab5ed455c"
+version = "5.2.0-pre.5"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.0-pre.5#ee8e46d8694e4144ecce7e3cc3e3773bad680314"
 dependencies = [
  "borsh",
  "digest",
@@ -3568,6 +3572,7 @@ dependencies = [
 [[package]]
 name = "tari_ootle_address"
 version = "0.16.0"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#1a3737043ac28324838946c1b664a66f07421856"
 dependencies = [
  "bech32",
  "serde",
@@ -3581,6 +3586,7 @@ dependencies = [
 [[package]]
 name = "tari_ootle_common_types"
 version = "0.16.0"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#1a3737043ac28324838946c1b664a66f07421856"
 dependencies = [
  "blake2",
  "borsh",
@@ -3607,6 +3613,7 @@ dependencies = [
 [[package]]
 name = "tari_ootle_storage"
 version = "0.16.0"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#1a3737043ac28324838946c1b664a66f07421856"
 dependencies = [
  "anyhow",
  "bitflags 2.9.4",
@@ -3631,6 +3638,7 @@ dependencies = [
 [[package]]
 name = "tari_ootle_wallet_crypto"
 version = "0.16.0"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#1a3737043ac28324838946c1b664a66f07421856"
 dependencies = [
  "argon2 0.5.3",
  "blake2",
@@ -3653,6 +3661,7 @@ dependencies = [
 [[package]]
 name = "tari_ootle_wallet_sdk"
 version = "0.16.0"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#1a3737043ac28324838946c1b664a66f07421856"
 dependencies = [
  "anyhow",
  "blake2",
@@ -3686,6 +3695,7 @@ dependencies = [
 [[package]]
 name = "tari_ootle_wallet_sdk_services"
 version = "0.16.0"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#1a3737043ac28324838946c1b664a66f07421856"
 dependencies = [
  "anyhow",
  "futures",
@@ -3711,6 +3721,7 @@ dependencies = [
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
 version = "0.16.0"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#1a3737043ac28324838946c1b664a66f07421856"
 dependencies = [
  "bigdecimal",
  "diesel",
@@ -3733,16 +3744,16 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "5.2.0-pre.4"
-source = "git+https://github.com/tari-project/tari.git?branch=development#d1772745dec8d231b54c689fcaf7470ab5ed455c"
+version = "5.2.0-pre.5"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.0-pre.5#ee8e46d8694e4144ecce7e3cc3e3773bad680314"
 dependencies = [
  "futures",
 ]
 
 [[package]]
 name = "tari_sidechain"
-version = "5.2.0-pre.4"
-source = "git+https://github.com/tari-project/tari.git?branch=development#d1772745dec8d231b54c689fcaf7470ab5ed455c"
+version = "5.2.0-pre.5"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.0-pre.5#ee8e46d8694e4144ecce7e3cc3e3773bad680314"
 dependencies = [
  "borsh",
  "hex",
@@ -3759,6 +3770,7 @@ dependencies = [
 [[package]]
 name = "tari_state_tree"
 version = "0.16.0"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#1a3737043ac28324838946c1b664a66f07421856"
 dependencies = [
  "log",
  "serde",
@@ -3773,6 +3785,7 @@ dependencies = [
 [[package]]
 name = "tari_template_abi"
 version = "0.14.0"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#1a3737043ac28324838946c1b664a66f07421856"
 dependencies = [
  "serde",
  "tari_bor",
@@ -3781,6 +3794,7 @@ dependencies = [
 [[package]]
 name = "tari_template_builtin"
 version = "0.16.0"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#1a3737043ac28324838946c1b664a66f07421856"
 dependencies = [
  "tari_template_lib",
 ]
@@ -3788,6 +3802,7 @@ dependencies = [
 [[package]]
 name = "tari_template_lib"
 version = "0.14.0"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#1a3737043ac28324838946c1b664a66f07421856"
 dependencies = [
  "borsh",
  "serde",
@@ -3800,6 +3815,7 @@ dependencies = [
 [[package]]
 name = "tari_template_lib_types"
 version = "0.14.0"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#1a3737043ac28324838946c1b664a66f07421856"
 dependencies = [
  "bnum",
  "borsh",
@@ -3812,6 +3828,7 @@ dependencies = [
 [[package]]
 name = "tari_template_macros"
 version = "0.14.0"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#1a3737043ac28324838946c1b664a66f07421856"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3823,6 +3840,7 @@ dependencies = [
 [[package]]
 name = "tari_transaction"
 version = "0.16.0"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#1a3737043ac28324838946c1b664a66f07421856"
 dependencies = [
  "borsh",
  "hex",
@@ -3834,6 +3852,7 @@ dependencies = [
  "tari_bor",
  "tari_crypto",
  "tari_engine_types",
+ "tari_hashing",
  "tari_ootle_common_types",
  "tari_template_lib",
  "thiserror 2.0.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ anyhow = "1.0.100"
 env_logger = "0.11.8"
 futures = "0.3.31"
 log = "0.4.28"
-clap = { version = "4.5.48", features = ["derive"] }
+clap = { version = "4.5.48", features = ["derive", "env"] }
 tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread"] }
 url = "2.5.7"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/transfer.sh
+++ b/transfer.sh
@@ -9,11 +9,11 @@ set -e
 
 
 # Example usage of the transfer commands in the CLI tool.
-ADDRESS=xtr_loc_15rdukntc5swqk2kqmyn004tj4ap83ekyvcahzwstxfql22cpfsm9fxq0ax6qsm2ylh3kfadrkhnvp5xtcgszvtmpswk4a64les34kcgkr3aa5
+ADDRESS=otl_loc_1pr4383l9dkhlz6m2yach2lvdrpnkx6jmhqpua53fmsuftk205f7q3x73ces8lcepmphmkhpmn4v957wmrnny4lp2n6p9s8dunuxqzyqlxu87n
 AMOUNT=10000000
 
 cargo run --release -- --network=localnet --password=123 -ihttp://localhost:12017  \
-  transfer create --to-address=$ADDRESS --amount=$AMOUNT --num-outputs=7 --message="Transfer" --fee-amount=1100 -o /tmp/transfer.json
+  transfer create --to-address=$ADDRESS --amount=$AMOUNT --num-outputs=7 --message="Transfer" --fee-amount=1300 -o /tmp/transfer.json
 cargo run --release -- --network=localnet --password=123 -ihttp://localhost:12017  transfer transaction /tmp/transfer.json /tmp/tx1.json
 cargo run --release -- --network=localnet --password=123 -ihttp://localhost:12017  transfer sign /tmp/tx1.json /tmp/tx1_signed.json
 cargo run --release -- --network=localnet --password=123 -ihttp://localhost:12017  transfer send /tmp/tx1_signed.json


### PR DESCRIPTION
This pull request introduces a new command to cancel pending transfers, improves environment variable support for configuration, and refactors the transfer transaction flow for better flexibility and correctness. The most important changes are grouped below:

### New Feature: Cancel Transfer Command

* Adds a `cancel-transfer` command to the CLI, allowing users to cancel a transfer by either specifying a lock ID or providing a transfer JSON file. This command interacts with the wallet SDK to release the associated lock and provides user feedback on success or error. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR155-R165) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR225-R258)

### Configuration Improvements

* Enables the use of environment variables (`OOTLE_DB_PATH`, `OOTLE_INDEXER_URL`, `OOTLE_NETWORK`) for key CLI arguments by adding the `env` feature to the `clap` dependency and updating argument definitions. This makes configuration more flexible and script-friendly. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L34-R34) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR55-R71)

### Transfer Transaction Flow Refactor

* Refactors the transfer transaction data structures by replacing `UnsignedTransactionOutput` with `UnsignedTransactionData`, which now includes `utxo_spend_keys` and renames `required_signer_key_id` to `seal_signer_key_id` for clarity. The signing flow is updated to use all required keys for correct transaction sealing. [[1]](diffhunk://#diff-2600c8993494c3e528388fc6124367794c6323250fac8b73455a47dc51079157L130-R134) [[2]](diffhunk://#diff-2600c8993494c3e528388fc6124367794c6323250fac8b73455a47dc51079157L147-R159) [[3]](diffhunk://#diff-2600c8993494c3e528388fc6124367794c6323250fac8b73455a47dc51079157L213-R218) [[4]](diffhunk://#diff-4db9c4cca2ff80c2ad80cbf7111959e148b31ee24cb354f8620c417047fe7b46R5) [[5]](diffhunk://#diff-4db9c4cca2ff80c2ad80cbf7111959e148b31ee24cb354f8620c417047fe7b46L21-R31) [[6]](diffhunk://#diff-4db9c4cca2ff80c2ad80cbf7111959e148b31ee24cb354f8620c417047fe7b46L663-R683)
* Updates the `Wallet::sign_transaction` method to collect and use all necessary keys (`seal_signer_key_id` and `utxo_spend_keys`) when signing transactions, ensuring proper authorization and compatibility with stealth outputs. [[1]](diffhunk://#diff-4db9c4cca2ff80c2ad80cbf7111959e148b31ee24cb354f8620c417047fe7b46L518-R560) [[2]](diffhunk://#diff-4db9c4cca2ff80c2ad80cbf7111959e148b31ee24cb354f8620c417047fe7b46L482-L509) [[3]](diffhunk://#diff-4db9c4cca2ff80c2ad80cbf7111959e148b31ee24cb354f8620c417047fe7b46R457) [[4]](diffhunk://#diff-4db9c4cca2ff80c2ad80cbf7111959e148b31ee24cb354f8620c417047fe7b46L410-R411) [[5]](diffhunk://#diff-4db9c4cca2ff80c2ad80cbf7111959e148b31ee24cb354f8620c417047fe7b46L371-R372) [[6]](diffhunk://#diff-4db9c4cca2ff80c2ad80cbf7111959e148b31ee24cb354f8620c417047fe7b46L590-L591)

### Minor Fixes and Script Updates

* Updates the example transfer script (`transfer.sh`) to use a new address format and adjusts the fee amount for demonstration purposes.
* Minor dependency and import adjustments to support the above changes. [[1]](diffhunk://#diff-2600c8993494c3e528388fc6124367794c6323250fac8b73455a47dc51079157L8-R8) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL14-R25)

These changes together improve the wallet CLI's usability, flexibility, and correctness, especially around transfer creation, signing, and cancellation.