### PR TITLE
chore: update ootle-rs to 0.12 via crates.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fmt:
+    name: Formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
+  clippy:
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --all-targets --all-features
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2136,7 +2136,8 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 [[package]]
 name = "ootle-network"
 version = "0.2.0"
-source = "git+https://github.com/tari-project/tari-ootle.git?tag=v0.33.4#031a073d966602754b61016b7891da2a5f017da1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa04b000c9d51e701385c1369c53b1123a81eec862d8c595e6c44e0beb8015"
 dependencies = [
  "minicbor",
  "serde",
@@ -2145,8 +2146,9 @@ dependencies = [
 
 [[package]]
 name = "ootle-rs"
-version = "0.10.0"
-source = "git+https://github.com/tari-project/tari-ootle.git?tag=v0.33.4#031a073d966602754b61016b7891da2a5f017da1"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa6548aae014f7facb8bf66edffbc6cb5936b74e724e4a70c7bd91cdfb1215d"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2199,7 +2201,8 @@ dependencies = [
 [[package]]
 name = "ootle_byte_type"
 version = "0.8.0"
-source = "git+https://github.com/tari-project/tari-ootle.git?tag=v0.33.4#031a073d966602754b61016b7891da2a5f017da1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99ed5152cd8bb0d86a177840f52370be19f01dad9dc671bb584b7091f3aa0e2a"
 dependencies = [
  "tari_crypto",
  "tari_template_lib_types",
@@ -2208,7 +2211,8 @@ dependencies = [
 [[package]]
 name = "ootle_serde"
 version = "0.3.0"
-source = "git+https://github.com/tari-project/tari-ootle.git?tag=v0.33.4#031a073d966602754b61016b7891da2a5f017da1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e62bc4bf713545a4636ad89ff60fc474a519aab100745214835b53e197642a44"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -3425,8 +3429,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tari_bor"
-version = "0.14.0"
-source = "git+https://github.com/tari-project/tari-ootle.git?tag=v0.33.4#031a073d966602754b61016b7891da2a5f017da1"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90726af209c7ac949301c0e65f729f7e95183733a030a711d42d14ed9872d35a"
 dependencies = [
  "borsh",
  "indexmap",
@@ -3458,9 +3463,9 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "5.4.0-pre.3"
+version = "5.4.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368364826f41d7eedb7a23acf154da06095d90dd0d58e75fc0ed5fe820bcd27c"
+checksum = "0e750a0c3e0a90b887c58ca0089838b56ae31bc831861c709b9be1e3d866114f"
 dependencies = [
  "anyhow",
  "cargo_toml 0.20.5",
@@ -3482,9 +3487,9 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "5.4.0-pre.3"
+version = "5.4.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0524755e1907db61bd3cfe1cd54910580f5bedfa0c5ea63f82ef93366231970e"
+checksum = "fe80cb70db417f9ead06dffdbf9648224d8199aa6685b88e212ff90773671145"
 dependencies = [
  "argon2 0.6.0-rc.8",
  "base64 0.22.1",
@@ -3520,8 +3525,9 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.33.4"
-source = "git+https://github.com/tari-project/tari-ootle.git?tag=v0.33.4#031a073d966602754b61016b7891da2a5f017da1"
+version = "0.34.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5190e7cc5b207b39bfe6d983c03021c572ff9c98e28418b6d3881804d7ba83"
 dependencies = [
  "borsh",
  "minicbor",
@@ -3561,8 +3567,9 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.33.4"
-source = "git+https://github.com/tari-project/tari-ootle.git?tag=v0.33.4#031a073d966602754b61016b7891da2a5f017da1"
+version = "0.34.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73d7565df19a5741fa26a01015afd407c83dca57535cbc01e00a149693641f4b"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -3590,15 +3597,15 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "5.4.0-pre.3"
+version = "5.4.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a6b5303e826b6c965395063cfea430425fa15471f6d3200eb1fa0f30afca82"
+checksum = "e71b38ff2d5de33a30b350d031ffee5a12906f4a14f88b482994eb4a9a58be2e"
 
 [[package]]
 name = "tari_hashing"
-version = "5.4.0-pre.3"
+version = "5.4.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8f27817fe6e51d01472828901aa0229bc4162127d3ed11193a961d4ee553e6"
+checksum = "a69ff43b336ff0cddc93cc2ca2f6f3717dc304e0dbba8b8e9b4b62c20f6233bc"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -3608,8 +3615,9 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_client"
-version = "0.32.2"
-source = "git+https://github.com/tari-project/tari-ootle.git?tag=v0.33.4#031a073d966602754b61016b7891da2a5f017da1"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11e14fa999bed4719a82fd5209b2b5ecfc7d97fbb53b36c9d2de73a92eca0449"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -3650,9 +3658,9 @@ dependencies = [
 
 [[package]]
 name = "tari_max_size"
-version = "5.4.0-pre.3"
+version = "5.4.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae2762c57918e27681d851b484640e5f7f836f3119b9b76ec9cc8401727c065f"
+checksum = "4364efa18264a97df678f97f540e7d05165f0d8cc54c2f2ff167cb10a425bf2f"
 dependencies = [
  "borsh",
  "serde",
@@ -3675,7 +3683,8 @@ dependencies = [
 [[package]]
 name = "tari_ootle_address"
 version = "0.6.0"
-source = "git+https://github.com/tari-project/tari-ootle.git?tag=v0.33.4#031a073d966602754b61016b7891da2a5f017da1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be93a3494f07bd590a818bb9e057520bb9ca095291098b7587cb01c1973365be"
 dependencies = [
  "bech32",
  "ootle-network",
@@ -3687,8 +3696,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.33.4"
-source = "git+https://github.com/tari-project/tari-ootle.git?tag=v0.33.4#031a073d966602754b61016b7891da2a5f017da1"
+version = "0.34.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d5f5bacd4d1c274597c3cf219cd8a0e38f57ef74bcb3aab892a45d0a7ab0396"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -3717,7 +3727,8 @@ dependencies = [
 [[package]]
 name = "tari_ootle_template_metadata"
 version = "0.7.0"
-source = "git+https://github.com/tari-project/tari-ootle.git?tag=v0.33.4#031a073d966602754b61016b7891da2a5f017da1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2869db740d797c733974cf8a098decceae256efce0f37aee3343445d5092015"
 dependencies = [
  "borsh",
  "cargo_toml 0.22.3",
@@ -3735,8 +3746,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.33.4"
-source = "git+https://github.com/tari-project/tari-ootle.git?tag=v0.33.4#031a073d966602754b61016b7891da2a5f017da1"
+version = "0.34.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad9e47481239ad010c9bd7774c6d0342da13bf869d7df7d1d1121094bb8752ec"
 dependencies = [
  "borsh",
  "hex",
@@ -3760,8 +3772,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.33.2"
-source = "git+https://github.com/tari-project/tari-ootle.git?tag=v0.33.4#031a073d966602754b61016b7891da2a5f017da1"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10cf2ccc4234e5bdcff93aab1e56c80c88a6725870017afd9e61ac84504908"
 dependencies = [
  "argon2 0.5.3",
  "blake2 0.10.6",
@@ -3805,7 +3818,8 @@ dependencies = [
 [[package]]
 name = "tari_template_abi"
 version = "0.17.1"
-source = "git+https://github.com/tari-project/tari-ootle.git?tag=v0.33.4#031a073d966602754b61016b7891da2a5f017da1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d02e8f3235e2c0421da21248efb2370631174081ddf2e0d8fc030df184fad95b"
 dependencies = [
  "minicbor",
  "serde",
@@ -3816,7 +3830,8 @@ dependencies = [
 [[package]]
 name = "tari_template_builtin"
 version = "0.32.0"
-source = "git+https://github.com/tari-project/tari-ootle.git?tag=v0.33.4#031a073d966602754b61016b7891da2a5f017da1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3ea94593eb371bed225c4ea1a0f406307bb09496f34dcb2bfa5a4aa0d42943c"
 dependencies = [
  "anyhow",
  "tari_template_lib_types",
@@ -3824,8 +3839,9 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib"
-version = "0.27.0"
-source = "git+https://github.com/tari-project/tari-ootle.git?tag=v0.33.4#031a073d966602754b61016b7891da2a5f017da1"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec68fc08a9cde8e709c6f8cb1bc078fcd1db6c794d0d95b595dcc2e8dc666b52"
 dependencies = [
  "borsh",
  "minicbor",
@@ -3838,8 +3854,9 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib_types"
-version = "0.27.0"
-source = "git+https://github.com/tari-project/tari-ootle.git?tag=v0.33.4#031a073d966602754b61016b7891da2a5f017da1"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "351ed3d15215e9878a0113746b6e391a41ab35976764f9a104aa25364b56115c"
 dependencies = [
  "bnum",
  "borsh",
@@ -3853,7 +3870,8 @@ dependencies = [
 [[package]]
 name = "tari_template_macros"
 version = "0.20.1"
-source = "git+https://github.com/tari-project/tari-ootle.git?tag=v0.33.4#031a073d966602754b61016b7891da2a5f017da1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32716528df28bcf1407c9cc40ada508cd34382dd5dee9d40ff7280aca8b05de9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,16 +7,16 @@ description = "Ootle Wallet Command Line Interface"
 license = "BSD-3-Clause"
 
 [dependencies]
-ootle-rs = { git = "https://github.com/tari-project/tari-ootle.git", tag = "v0.33.4" }
-tari_template_lib_types = { git = "https://github.com/tari-project/tari-ootle.git", tag = "v0.33.4" }
-tari_ootle_common_types = { git = "https://github.com/tari-project/tari-ootle.git", tag = "v0.33.4" }
+ootle-rs = "0.12.0"
+tari_template_lib_types = "0.27"
+tari_ootle_common_types = "0.34"
 
 #ootle-rs = { path = "../dan/crates/wallet/ootle-rs" }
 #tari_template_lib_types = { path = "../dan/crates/template_lib_types" }
 #tari_ootle_common_types = { path = "../dan/crates/common_types" }
 
 tari_crypto = { version = "0.23", features = ["std"] }
-tari_common_types = "5.4.0-pre.3"
+tari_common_types = "5.4.0-pre.5"
 
 anyhow = "1.0.100"
 env_logger = "0.11.8"
@@ -33,5 +33,5 @@ termimad = "0.34.0"
 zeroize = "1.8.2"
 
 [[bin]]
-name = "ootle"
+name = "ootle-wallet"
 path = "src/main.rs"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ cargo build --release
 
 ```bash
 # Show help
-ootle --help
+ootle-wallet --help
 ```
 
 Common options (apply to all commands):
@@ -39,13 +39,13 @@ Runs you through the initial wallet setup: network, indexer URL, an optional pas
 new (or restored) seed words, the first account, and faucet funding on testnets:
 
 ```bash
-ootle setup
+ootle-wallet setup
 
 # Non-interactive
-ootle -n esmeralda setup --account-name main --no-fund
+ootle-wallet -n esmeralda setup --account-name main --no-fund
 
 # Restore a wallet from existing seed words
-ootle setup --restore
+ootle-wallet setup --restore
 ```
 
 The network and indexer URL are stored in the wallet database. Default indexer URLs:
@@ -55,59 +55,59 @@ The network and indexer URL are stored in the wallet database. Default indexer U
 
 ```bash
 # Change the indexer API URL (empty value resets to the network default)
-ootle set indexer-url https://my-indexer.example.com/
-ootle set indexer-url ""
+ootle-wallet set indexer-url https://my-indexer.example.com/
+ootle-wallet set indexer-url ""
 
 # Change the network (account addresses are re-encoded for the new network)
-ootle set network localnet
+ootle-wallet set network localnet
 ```
 
 ### Accounts and keys
 
 ```bash
 # Create another account (funds it from the faucet on testnets and prints its keys)
-ootle create-account --name alice
+ootle-wallet create-account --name alice
 
 # List accounts in the wallet
-ootle list-accounts
+ootle-wallet list-accounts
 
 # Show the keys of an account, including the secret account and view keys
-ootle show-keys -a alice
+ootle-wallet show-keys -a alice
 
 # Show the wallet seed words
-ootle show-seed-words
+ootle-wallet show-seed-words
 
 # Change the default account
-ootle set-default-account -n alice
+ootle-wallet set-default-account -n alice
 ```
 
 ### Get testnet funds
 
 ```bash
 # Fund the default account from the testnet faucet
-ootle faucet
+ootle-wallet faucet
 
 # Fund a specific account
-ootle faucet -a alice
+ootle-wallet faucet -a alice
 ```
 
 ### Check balances, vaults and resources
 
 ```bash
 # Default account
-ootle balance
+ootle-wallet balance
 
 # A specific account, or any address
-ootle balance -a alice
-ootle balance --address otl_esm_1...
+ootle-wallet balance -a alice
+ootle-wallet balance --address otl_esm_1...
 
 # List the on-chain vaults of an account (vault ID, resource, balances)
-ootle vaults
-ootle vaults -a alice
+ootle-wallet vaults
+ootle-wallet vaults -a alice
 
 # List the resources held by an account, aggregated across its vaults
-ootle resources
-ootle resources --address otl_esm_1...
+ootle-wallet resources
+ootle-wallet resources --address otl_esm_1...
 ```
 
 ### Transfer
@@ -115,17 +115,17 @@ ootle resources --address otl_esm_1...
 Public transfer of XTR to another address (amounts are in micro XTR):
 
 ```bash
-ootle transfer -t otl_esm_1... -a 1000000
+ootle-wallet transfer -t otl_esm_1... -a 1000000
 
 # From a specific account with a custom max fee
-ootle transfer -s alice -t otl_esm_1... -a 1000000 -f 2000
+ootle-wallet transfer -s alice -t otl_esm_1... -a 1000000 -f 2000
 ```
 
 ### Transaction history
 
 ```bash
-ootle history
-ootle history -a alice
+ootle-wallet history
+ootle-wallet history -a alice
 ```
 
 ## Development
@@ -135,6 +135,6 @@ cargo build
 cargo run -- --help
 ```
 
-The Ootle crates are pinned to a `tari-ootle` release tag in `Cargo.toml`. To develop
-against a local checkout, comment out the `git` dependencies and uncomment the `path`
-dependencies pointing at `../dan`.
+The Ootle crates (`ootle-rs`, `tari_template_lib_types`, `tari_ootle_common_types`) are
+pulled from crates.io in `Cargo.toml`. To develop against a local checkout, comment out the
+crates.io dependencies and uncomment the `path` dependencies pointing at `../dan`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ const DEFAULT_FEE: u64 = 1_000;
 const TRANSACTION_TIMEOUT: Duration = Duration::from_secs(120);
 
 #[derive(Parser)]
-#[command(name = "ootle", about = "Ootle wallet CLI")]
+#[command(name = "ootle-wallet", about = "Ootle wallet CLI")]
 struct Cli {
     #[command(flatten)]
     common: CommonArgs,
@@ -1079,7 +1079,7 @@ fn resolve_network(common: &CommonArgs, store: &WalletStore) -> anyhow::Result<N
         ),
         (_, Some(db)) => Ok(db),
         (Some(flag), None) => Ok(flag),
-        (None, None) => bail!("Wallet is not set up. Run `ootle setup` first"),
+        (None, None) => bail!("Wallet is not set up. Run `ootle-wallet setup` first"),
     }
 }
 
@@ -1091,7 +1091,7 @@ fn load_cipher_seed(
 ) -> anyhow::Result<(CipherSeed, Option<SafePassword>)> {
     let enciphered = store
         .enciphered_cipher_seed()?
-        .ok_or_else(|| anyhow::anyhow!("Wallet is not set up. Run `ootle setup` first"))?;
+        .ok_or_else(|| anyhow::anyhow!("Wallet is not set up. Run `ootle-wallet setup` first"))?;
     let passphrase = common.password.clone().map(SafePassword::from);
     match CipherSeed::from_enciphered_bytes(&enciphered, passphrase.clone()) {
         Ok(seed) => Ok((seed, passphrase)),


### PR DESCRIPTION
## Summary
Switch the `tari-ootle` dependencies from git tags to published **crates.io** releases and bump `ootle-rs` **0.10.0 → 0.12.0**.

## Changes
- `ootle-rs = "0.12.0"` (was git tag `v0.33.4`)
- `tari_template_lib_types = "0.27"` → resolves `0.27.2` (matches `ootle-rs` `^0.27`)
- `tari_ootle_common_types = "0.34"` → resolves `0.34.1` (matches `ootle-rs` `^0.34`)
- `tari_common_types = "5.4.0-pre.5"` (was `pre.3`)
- Rename the binary to `ootle-wallet`

## Notes
- No source changes were required — the 0.10 → 0.12 jump compiled cleanly.
- Release build (`cargo build --release`) is clean; `cargo fmt` produced no changes.
- Lockfile now resolves all ootle crates from `registry+https://github.com/rust-lang/crates.io-index` (no remaining git deps on `tari-ootle`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)